### PR TITLE
Cleanup and windows

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -59,4 +59,4 @@ jobs:
                   composer-options: ${{ matrix.composer-options }} --prefer-dist
 
             - name: Tests
-              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist
+              run: vendor/bin/simple-phpunit

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -13,11 +13,16 @@ on:
                 required: false
                 default: 7.2.5
                 type: string
+            runs-on:
+                description: The "runs-on" platform config
+                required: false
+                default: 'ubuntu-latest'
+                type: string
 
 jobs:
     phpunit:
         name: PHP ${{ matrix.php-version }}, ${{ matrix.dependency-versions }} deps, ${{ matrix.composer-options }}
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runs-on }}
 
         strategy:
             fail-fast: false

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -13,11 +13,6 @@ on:
                 required: false
                 default: 7.2.5
                 type: string
-            phpunit:
-                description: PHPUnit script (phpunit/simple-phpunit)
-                required: false
-                default: phpunit
-                type: string
 
 jobs:
     phpunit:

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -58,14 +58,5 @@ jobs:
                   dependency-versions: ${{ matrix.dependency-versions }}
                   composer-options: ${{ matrix.composer-options }} --prefer-dist
 
-            - name: Unit Tests
-              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
-
-            - name: Functional Tests
-              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional
-
-            - name: Integration Tests
-              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite integration
-
-            - name: Acceptance Tests
-              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite acceptance
+            - name: Tests
+              run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ The list of repositories that are dependent on this repo:
 - [symfonycasts/reset-password-bundle](https://github.com/SymfonyCasts/reset-password-bundle)
 - [symfonycasts/verify-email-bundle](https://github.com/SymfonyCasts/verify-email-bundle)
 - [symfonycasts/messenger-monitor-bundle](https://github.com/SymfonyCasts/messenger-monitor-bundle)
+- [symfonycasts/tailwind-bundle](https://github.com/SymfonyCasts/tailwind-bundle)


### PR DESCRIPTION
Hi!

3 things:

1) Remove the different test suites from being run independently. I don't see a lot of value to this and it meant that I was accidentally running NO tests for TailwindBundle, since I didn't have the testsuites config. So I'd like to simplify.

2) Removed what I believe is an unused `phpunit` input

3) Make `runs-on` dynamic so the job could be re-used for windows.

Here is a PR using this new setup: https://github.com/SymfonyCasts/tailwind-bundle/pull/4