### PR TITLE
Drop legacy PHP support

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -6,12 +6,12 @@ on:
             php-version-matrix:
                 description: PHP versions used in the matrix
                 required: false
-                default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+                default: '["8.1", "8.2", "8.3"]'
                 type: string
             php-version-lowest:
                 description: PHP version for testing lowest deps
                 required: false
-                default: 7.2.5
+                default: 8.1
                 type: string
             runs-on:
                 description: The "runs-on" platform config


### PR DESCRIPTION
@weaverryan according to https://github.com/SymfonyCasts/verify-email-bundle/pull/148#discussion_r1412806782 and since 7.2 started causing CI failures probably it's time to drop legacy PHP versions support.

In particular, this PR drops support of PHP 7 and 8.0 - all are EOL now: https://www.php.net/supported-versions.php

Affected bundles:
- knpuniversity/oauth2-client-bundle - supports PHP 7.4+
- SymfonyCasts/reset-password-bundle - supports PHP 7.2+
- SymfonyCasts/verify-email-bundle - supports PHP 7.2+