### PR TITLE
[phpstan] install phpunit via simple-phpunit

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -8,6 +8,11 @@ on:
                 default: 8.2
                 required: false
                 type: string
+            install-phpunit-bridge:
+                description: Installs PHPUnit before running PHPStan
+                default: false
+                required: false
+                type: boolean
 
 jobs:
     phpstan:
@@ -24,6 +29,10 @@ jobs:
 
             - name: Install Composer dependencies
               run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+            - name: Install PHPUnit (simple-phpunit)
+              if: ${{ true == inputs.install-phpunit-bridge }}
+              run: vendor/bin/simple-phpunit --version
 
             - name: Run PHPStan
               run: vendor/bin/phpstan analyse


### PR DESCRIPTION
for repos that use PHPUnit Bridge - phpunit needs to be installed before running phpstan against tests.

## In the consumer:

- set `install-phpunit-bridge: true` to install PHPUnit via `vendor/bin/simple-phpunit`

- setting `install-phpunit-bridge` to any other value than `true` _OR_ omitting `install-phpunit-bridge` will skip this step