### PR TITLE
dont depend on phpstan as project dependency

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -34,5 +34,9 @@ jobs:
               if: ${{ true == inputs.install-phpunit-bridge }}
               run: vendor/bin/simple-phpunit --version
 
+            - name: Install PHPStan
+              run: composer upgrade --no-progress --no-scripts --prefer-dist --working-dir=tools/phpstan
+
             - name: Run PHPStan
-              run: vendor/bin/phpstan analyse
+              run: tools/phpstan/vendor/bin/phpstan analyse
+


### PR DESCRIPTION
Implementing `tools/phpstan` in say `reset-password-bundle`, so we can remove the dependency requirement in the project's `composer.json` (`require-dev`), causes the test suite to blow up. our global phpstan CI run looks for `vendor/bin/phpstan`. This changes it to `tools/phpstan/vendor/bin/phpstan` .

---

Review / update these repos _if_ they're using `phpstan` as a project dependency (implement `tools/*` & composer scripts)

 - [x] knpuniversity/oauth2-client-bundle https://github.com/knpuniversity/oauth2-client-bundle/pull/445
 - [x] symfonycasts/reset-password-bundle https://github.com/SymfonyCasts/reset-password-bundle/pull/325
 - [x] symfonycasts/verify-email-bundle https://github.com/SymfonyCasts/verify-email-bundle/pull/188
 - [x] symfonycasts/messenger-monitor-bundle https://github.com/SymfonyCasts/messenger-monitor-bundle/pull/59
 - [x] symfonycasts/tailwind-bundle https://github.com/SymfonyCasts/tailwind-bundle/pull/59
 - [x] symfonycasts/sass-bundle https://github.com/SymfonyCasts/sass-bundle/pull/70
 - [x] symfonycasts/micro-mapper https://github.com/SymfonyCasts/micro-mapper/pull/13
 - [x] symfonycasts/dynamic-forms https://github.com/SymfonyCasts/dynamic-forms/pull/28